### PR TITLE
Implemented: adding_Glide_library_keeping_androidX_dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.0.0-rc01"
     implementation "androidx.constraintlayout:constraintlayout:1.1.2"
     implementation "androidx.recyclerview:recyclerview:1.0.0-beta01"
-    implementation('com.github.bumptech.glide:glide:4.7.1') {
-        exclude group: "com.android.support"
-    }
-    implementation 'com.github.bumptech.glide:compiler:4.7.1'
+    implementation 'com.github.bumptech.glide:glide:4.7.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.7.1'
 }

--- a/app/src/main/java/com/example/kirill/myapplication/Actor.java
+++ b/app/src/main/java/com/example/kirill/myapplication/Actor.java
@@ -17,4 +17,7 @@ public class Actor {
 
     public String getName() { return name; }
 
+    public Uri getAvatar() {
+        return avatar;
+    }
 }

--- a/app/src/main/java/com/example/kirill/myapplication/ActorRecyclerAdapter.java
+++ b/app/src/main/java/com/example/kirill/myapplication/ActorRecyclerAdapter.java
@@ -9,6 +9,7 @@ import android.widget.ImageView;
 import java.util.List;
 
 import androidx.recyclerview.widget.RecyclerView;
+import com.bumptech.glide.Glide;
 
 
 public class ActorRecyclerAdapter extends RecyclerView.Adapter<ActorRecyclerAdapter.ViewHolder> {
@@ -47,9 +48,6 @@ public class ActorRecyclerAdapter extends RecyclerView.Adapter<ActorRecyclerAdap
     public void onBindViewHolder(ViewHolder holder, int position) {
         // get our custom object from our dataset at this position
         Actor actor = actors.get(position);
-
-        // Fill views with our data
+        Glide.with(holder.avatar).load(actor.getAvatar()).into(holder.avatar);
     }
-
-
 }


### PR DESCRIPTION
This is a 2nd solution that makes Glide available for use in the project work. I literally did nothing to solve strange build problems **except** cleaning build caches . 
I also removed from `build.gradle` redundant statements. 

Before merging (if you still need it), please, check out my solution as is to see if it works on your machine (just clone my repository and check out to relevant commit: https://github.com/VladZamskoi-AndroidAcademy-Minsk-2018/androidLearning/commit/951a5c182ca529a9d4df8fa2c2bd6c365f2659ae)